### PR TITLE
Fixed turtle sprite not showing in Farm Buildings section / Changes regarding the RareCrowsSection

### DIFF
--- a/src/gamesave/GameSave.tsx
+++ b/src/gamesave/GameSave.tsx
@@ -38,6 +38,7 @@ export class GameSave {
   // public readonly slimeHutches;
 
   public readonly rarecrowsPlaced;
+  public readonly allRarecrows;
 
   public readonly specialOrders;
   public readonly qiSpecialOrders;
@@ -77,6 +78,7 @@ export class GameSave {
     this.fishPonds = this.calcFishPonds();
 
     this.rarecrowsPlaced = this.calcRarecrowsPlaced();
+    this.allRarecrows = this.calcAllRarecrows();
 
     this.specialOrders = this.calcSpecialOrders();
     this.qiSpecialOrders = this.calcQiSpecialOrders();
@@ -299,6 +301,41 @@ export class GameSave {
       .map((objectNode) => objectNode.query("itemId").text())
       .reduce((counts, rarecrowId) => {
         counts[rarecrowId]++;
+        return counts;
+      }, placedRarecrows);
+  }
+
+  private calcAllRarecrows() {
+    const placedRarecrows = mapToObj(STARDEW_RARECROW_IDS, (id) => [id, 0]);
+
+    const storedRarecrows = this.saveXml
+      .queryAll("item > value > Object")
+      .filter(
+        (buildingNode) => {
+          return buildingNode.element?.getAttribute("xsi:type") === "Chest"
+        }
+      )
+      .flatMap((chestNode) => {
+        const items = chestNode.queryAll("items");
+        if (items.length === 0) {
+          return [];
+        } else {
+          return chestNode.queryAll("items > Item")
+            .filter(
+              (objectNode) =>
+                objectNode.query("name").text() === "Rarecrow"
+            )
+        }
+      })
+      .map((objectNode) => objectNode.query("itemId").text())
+      .reduce((counts, rarecrowId) => {
+        counts[rarecrowId]++;
+        return counts;
+      }, placedRarecrows);        
+
+    return Object.entries(storedRarecrows)
+      .reduce((counts, [rarecrowId]) => {
+        counts[rarecrowId] += this.rarecrowsPlaced[rarecrowId];
         return counts;
       }, placedRarecrows);
   }

--- a/src/section/FarmBuildingsSection/FarmBuildingsSection.tsx
+++ b/src/section/FarmBuildingsSection/FarmBuildingsSection.tsx
@@ -84,9 +84,15 @@ export const FarmBuildingsSection = (props: Props) => {
         animals={props.gameSave.pets.map((pet) => ({
           name: pet.name,
           lovePercentage: pet.love / 1000,
-          wikiUrl: StardewWiki.getLink(pet.type),
+          //Website doesn't redirect /Turtle to /Animals#Turtle
+          wikiUrl: pet.type == "Turtle"
+            ? "https://stardewvalleywiki.com/Animals#Turtle" 
+            : StardewWiki.getLink(pet.type),
+          //Turtles don't have a breed
           iconSrc: FARM_ANIMALS_SPRITES.resolve(
-            snakeCase(pet.type) + "_" + pet.breed
+            pet.type == "Turtle"
+            ? "turtle"
+            : snakeCase(pet.type) + "_" + pet.breed
           ),
           iconHeight: 50,
         }))}

--- a/src/section/RarecrowsSection/RarecrowsSection.tsx
+++ b/src/section/RarecrowsSection/RarecrowsSection.tsx
@@ -22,8 +22,9 @@ export const RarecrowSection = (props: Props) => {
   const allCollected =
     // Either everyone got the letter
     farmers.every((farmer) => farmer.rarecrowSocietyMailed) ||
-    // Or at least 1 of each Rarecrow is currently placed down across the Valley
-    values(props.gameSave.rarecrowsPlaced).every((v) => v > 0);
+    // Or at least 1 of each Rarecrow is either currently placed down across the Valley
+    // Or currently inside a chest across the Valley
+    values(props.gameSave.allRarecrows).every((v) => v > 0);
 
   const totalPlaced = sum(values(props.gameSave.rarecrowsPlaced));
 
@@ -89,7 +90,7 @@ export const RarecrowSection = (props: Props) => {
           >
             <ImageObjective
               done={
-                allCollected || props.gameSave.rarecrowsPlaced[rarecrowId] > 0
+                allCollected || props.gameSave.allRarecrows[rarecrowId] > 0
               }
               height={100}
               title={`Rarecrow #${index + 1}`}
@@ -149,7 +150,7 @@ export const RarecrowSection = (props: Props) => {
               {" "}
               — Completed{" "}
               {
-                values(props.gameSave.rarecrowsPlaced).filter((x) => x > 0)
+                values(props.gameSave.allRarecrows).filter((x) => x > 0)
                   .length
               }{" "}
               out of {STARDEW_RARECROW_IDS.length}


### PR DESCRIPTION
Turtle's sprite wasn't correct because "turtle.png" did not fit the "snakeCase(pet.type) + "_" + pet.breed" format, and its link to the wiki was broken because "https://stardewvalleywiki.com/Turtle" does not redirect to "https://stardewvalleywiki.com/Animals#Turtle" as other pet's type do.

Added the variable 'allRarecrows'  to "GameSave.tsx", so now the RareCrowSection will also consider rarecrows inside chests for the completion section.